### PR TITLE
Modernize Syntax Rules

### DIFF
--- a/ftdetect/urscript.vim
+++ b/ftdetect/urscript.vim
@@ -18,4 +18,4 @@
 " You should have received a copy of the GNU General Public License
 " along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-au BufRead,BufNewFile *.{ur,urs,urscript} set filetype=urscript
+au BufRead,BufNewFile *.{ur,urs,urscript,script} set filetype=urscript

--- a/ftdetect/urscript.vim
+++ b/ftdetect/urscript.vim
@@ -18,4 +18,4 @@
 " You should have received a copy of the GNU General Public License
 " along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-au BufRead,BufNewFile *.{ur,urs,urscript,script} set filetype=urscript
+au BufRead,BufNewFile *.{ur,urs,urscript} set filetype=urscript

--- a/indent/urscript.vim
+++ b/indent/urscript.vim
@@ -60,13 +60,13 @@ function GetURScriptIndent(lnum)
 	" Extra indent to add.
 	let add_indent = 0
 
-	" Indent after lines ending in colon.
-	if prev_line =~ '^[^#]*:\s*\%(#.*\)\?$'
+	" Indent after lines ending in colon or containing 'enter_critical' keyword
+	if prev_line =~ '^[^#]*:\s*\%(#.*\)\?$' || prev_line =~ '^\s*enter_critical\>'
 		let add_indent = add_indent + shiftwidth()
 	endif
 
-	" Unindent elif/else/end.
-	if line =~ '^\s*\(elif\|else\|end\)\>'
+	" Unindent elif/else/end/exit_critical.
+	if line =~ '^\s*\(elif\|else\|end\|exit_critical\)\>'
 		let add_indent = add_indent - shiftwidth()
 	endif
 

--- a/indent/urscript.vim
+++ b/indent/urscript.vim
@@ -61,7 +61,7 @@ function GetURScriptIndent(lnum)
 	let add_indent = 0
 
 	" Indent after lines ending in colon.
-	if prev_line =~ ':\s*$'
+	if prev_line =~ '^[^#]*:\s*\%(#.*\)\?$'
 		let add_indent = add_indent + shiftwidth()
 	endif
 

--- a/indent/urscript.vim
+++ b/indent/urscript.vim
@@ -39,18 +39,13 @@ function GetURScriptIndent(lnum)
 	while prev_lnum >= a:lnum - 50 && prev_lnum >= 0
 		let prev_lnum = prevnonblank(prev_lnum - 1)
 		let prev_line = getline(prev_lnum)
-		if prev_line !~ '^\$'
+		if prev_line !~ '^\s*\$'
 			break
 		endif
 	endwhile
 
 	let prev_indent = indent(prev_lnum)
 	let line        = getline(a:lnum)
-
-	" Program labels may not be indented.
-	if line =~ '^\s*\$'
-		return 0
-	endif
 
 	" If this is the first line, use 0 indent.
 	if prev_lnum == 0

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -47,6 +47,9 @@ syn match  urscriptLabelNumber     "\d\+"     contained nextgroup=urscriptLabelT
 syn match  urscriptLabel           "^[$]"     nextgroup=urscriptLabelNumber skipwhite
 syn match  urscriptLabelError      "^\s\+[$]" nextgroup=urscriptLabelNumber skipwhite
 
+" Structure definition.
+syn keyword urscriptStruct struct
+
 " Pose definition.
 syn match urscriptPose "\<p\ze\["
 
@@ -91,6 +94,7 @@ hi def link urscriptLabelNumber Number
 hi def link urscriptLabel       PreProc
 hi def link urscriptLabelError  Error
 
+hi def link urscriptStruct      Structure
 hi def link urscriptPose        Structure
 hi def link urscriptNone        Constant
 hi def link urscriptString      String

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -34,7 +34,7 @@ syn match urscriptIdentifier "\<[a-zA-Z_][a-zA-Z0-9_]*\>" contained
 
 " Keywords.
 syn keyword urscriptKeywords thread run join kill return halt break continue
-syn keyword urscriptKeywords while if else elif end
+syn keyword urscriptKeywords while if else elif end enter_critical exit_critical
 syn keyword urscriptKeywords local global
 syn keyword urscriptKeywords def thread nextgroup=urscriptIdentifier skipwhite
 

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -33,7 +33,7 @@ syn keyword urscriptTodo TODO contained
 syn match urscriptIdentifier "\<[a-zA-Z_][a-zA-Z0-9_]*\>" contained
 
 " Keywords.
-syn keyword urscriptKeywords thread run join kill return halt break continue
+syn keyword urscriptKeywords thread run join kill return pause halt break continue
 syn keyword urscriptKeywords while if else elif end enter_critical exit_critical
 syn keyword urscriptKeywords local global
 syn keyword urscriptKeywords def thread nextgroup=urscriptIdentifier skipwhite

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -47,6 +47,9 @@ syn match  urscriptLabelNumber     "\d\+"     contained nextgroup=urscriptLabelT
 syn match  urscriptLabel           "^[$]"     nextgroup=urscriptLabelNumber skipwhite
 syn match  urscriptLabelError      "^\s\+[$]" nextgroup=urscriptLabelNumber skipwhite
 
+" Literal None value.
+syn keyword urscriptNone None
+
 " Strings.
 syn region  urscriptString start="\"" skip="\\" end="\""
 
@@ -85,6 +88,7 @@ hi def link urscriptLabelNumber Number
 hi def link urscriptLabel       PreProc
 hi def link urscriptLabelError  Error
 
+hi def link urscriptNone        Constant
 hi def link urscriptString      String
 hi def link urscriptBool        Constant
 hi def link urscriptNumber      Number

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -89,9 +89,9 @@ hi def link urscriptKeywords    Keyword
 hi def link urscriptOperators   Operator
 hi def link urscriptIdentifier  Identifier
 
-hi def link urscriptLabelProperty String
-hi def link urscriptLabelText     String
-hi def link urscriptLabelNumber   Number
+hi def link urscriptLabelProperty PreProc
+hi def link urscriptLabelText     PreProc
+hi def link urscriptLabelNumber   PreProc
 hi def link urscriptLabel         PreProc
 
 hi def link urscriptStruct      Structure

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -44,8 +44,7 @@ syn keyword urscriptOperators or and xor not
 " Program labels.
 syn region urscriptLabelText      start="\"" skip="\\" end="\""  contained
 syn match  urscriptLabelNumber     "\d\+"     contained nextgroup=urscriptLabelText skipwhite
-syn match  urscriptLabel           "^[$]"     nextgroup=urscriptLabelNumber skipwhite
-syn match  urscriptLabelError      "^\s\+[$]" nextgroup=urscriptLabelNumber skipwhite
+syn match  urscriptLabel           "^\s*[$]"  nextgroup=urscriptLabelNumber skipwhite
 
 " Structure definition.
 syn keyword urscriptStruct struct
@@ -92,7 +91,6 @@ hi def link urscriptIdentifier  Identifier
 hi def link urscriptLabelText   String
 hi def link urscriptLabelNumber Number
 hi def link urscriptLabel       PreProc
-hi def link urscriptLabelError  Error
 
 hi def link urscriptStruct      Structure
 hi def link urscriptPose        Structure

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -47,6 +47,9 @@ syn match  urscriptLabelNumber     "\d\+"     contained nextgroup=urscriptLabelT
 syn match  urscriptLabel           "^[$]"     nextgroup=urscriptLabelNumber skipwhite
 syn match  urscriptLabelError      "^\s\+[$]" nextgroup=urscriptLabelNumber skipwhite
 
+" Pose definition.
+syn match urscriptPose "\<p\ze\["
+
 " Literal None value.
 syn keyword urscriptNone None
 
@@ -88,6 +91,7 @@ hi def link urscriptLabelNumber Number
 hi def link urscriptLabel       PreProc
 hi def link urscriptLabelError  Error
 
+hi def link urscriptPose        Structure
 hi def link urscriptNone        Constant
 hi def link urscriptString      String
 hi def link urscriptBool        Constant

--- a/syntax/urscript.vim
+++ b/syntax/urscript.vim
@@ -42,7 +42,8 @@ syn keyword urscriptKeywords def thread nextgroup=urscriptIdentifier skipwhite
 syn keyword urscriptOperators or and xor not
 
 " Program labels.
-syn region urscriptLabelText      start="\"" skip="\\" end="\""  contained
+syn region urscriptLabelProperty  start="\"" skip="\\" end="\""  contained
+syn region urscriptLabelText      start="\"" skip="\\" end="\""  contained nextgroup=urscriptLabelProperty skipwhite
 syn match  urscriptLabelNumber     "\d\+"     contained nextgroup=urscriptLabelText skipwhite
 syn match  urscriptLabel           "^\s*[$]"  nextgroup=urscriptLabelNumber skipwhite
 
@@ -88,9 +89,10 @@ hi def link urscriptKeywords    Keyword
 hi def link urscriptOperators   Operator
 hi def link urscriptIdentifier  Identifier
 
-hi def link urscriptLabelText   String
-hi def link urscriptLabelNumber Number
-hi def link urscriptLabel       PreProc
+hi def link urscriptLabelProperty String
+hi def link urscriptLabelText     String
+hi def link urscriptLabelNumber   Number
+hi def link urscriptLabel         PreProc
 
 hi def link urscriptStruct      Structure
 hi def link urscriptPose        Structure


### PR DESCRIPTION
This PR updates the indentation and highlighting rules to better reflect modern URScript (circa UR SW 5.21). It also adds a file detection rule to treat .script files as URScript. 

Please let me know if you would like this change set broken up over several PRs.